### PR TITLE
Update sqlite3.lua

### DIFF
--- a/sqlite3.lua
+++ b/sqlite3.lua
@@ -125,11 +125,12 @@ local function getOSInfo()
 	end
 
 	--test for mac
-	hCommand = io.popen("sw_vers -productVersion");
+	hCommand = io.popen("sw_vers -productName");
 	sCommand = hCommand:read("*a");
 		
 	if sCommand:lower():find("mac") then
 	tSettings.SystemType = "mac";
+    tSettings.SystemBits = "64";
 	return
 	end
 	


### PR DESCRIPTION
change for mac support
Error i get now :
Error

error loading module 'lsqlite3' from file 'Users/$USER/Documents/Developement/love2d/KoboCollections/libs/lsqlite3.so':
dlopen(Users/$USER/Documents/Developement/love2d/KoboCollections/libs/lsqlite3.so, 6): no suitable image found.  Did find:
file system relative paths not allowed in hardened programs

Traceback

[C]: at 0x0106a65740
[C]: in function 'require'
libs/sqlite3.lua:279: in function 'init'
libs/sqlite3.lua:1032: in main chunk
[C]: in function 'require'
main.lua:7: in main chunk
[C]: in function 'require'
[C]: in function 'xpcall'
[C]: in function 'xpcall'